### PR TITLE
Specify that the mach service you're connecting to is privileged

### DIFF
--- a/SMJobBlessApp/SMJobBlessAppController.m
+++ b/SMJobBlessApp/SMJobBlessAppController.m
@@ -79,7 +79,7 @@ Copyright (C) 2011 Apple Inc. All Rights Reserved.
     
     self.textField.stringValue = @"Helper available.";
     
-    xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.bsd.SMJobBlessHelper", NULL, 0);
+    xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.bsd.SMJobBlessHelper", NULL, XPC_CONNECTION_MACH_SERVICE_PRIVILEGED);
     
     if (!connection) {
         [self appendLog:@"Failed to create XPC connection."];


### PR DESCRIPTION
Hi there,

Took me a good while to figure this one out :)

If you don't specify XPC_CONNECTION_MACH_SERVICE_PRIVILEGED when connecting to the mach service, the app works in Xcode for some reason, but won't work if launched outside of Xcode (or in things like Instruments).

I wish I knew why it works in Xcode, as it makes sense once you read the docs for that constant, but for now I'm happy that I've worked out why things didn't work when I deployed them!

-- Michael
