### PR TITLE
append to the textfield only on the main thread

### DIFF
--- a/SMJobBlessApp/SMJobBlessAppController.m
+++ b/SMJobBlessApp/SMJobBlessAppController.m
@@ -67,7 +67,9 @@ Copyright (C) 2011 Apple Inc. All Rights Reserved.
 @synthesize textField=_textField;
 
 - (void)appendLog:(NSString *)log {
-    self.textField.stringValue = [self.textField.stringValue stringByAppendingFormat:@"\n%@", log];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.textField.stringValue = [self.textField.stringValue stringByAppendingFormat:@"\n%@", log];
+    });
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {


### PR DESCRIPTION
Modern Xcode versions complain when anything UI related happens anywhere other than the main thread.  

This PR should fix that.

